### PR TITLE
Use proper authorization handler name

### DIFF
--- a/app/views/decidim/verify_wo_registration/verifications/_form.html.erb
+++ b/app/views/decidim/verify_wo_registration/verifications/_form.html.erb
@@ -2,7 +2,7 @@
   <div class="card-section">
     <div class="card__header collapse">
       <h5 class="card__title">
-        <%= t("authorize_with", authorizer: handler.handler_name, scope: "decidim.verifications.authorizations.new") %>
+        <%= t("authorize_with", authorizer: t("#{handler.handler_name}.name", scope: "decidim.authorization_handlers"), scope: "decidim.verifications.authorizations.new") %>
       </h5>
     </div>
 


### PR DESCRIPTION
The form is using the wrong authorization handler name:

Before this PR:

![image](https://user-images.githubusercontent.com/491891/104292999-c7a58e00-54bd-11eb-992f-46a5ed1e72d6.png)

After this PR:

![image](https://user-images.githubusercontent.com/491891/104293035-d5f3aa00-54bd-11eb-8406-94ca12c429b2.png)

Check how the "Verifica amb" string changes.