### PR TITLE
Fix verification step

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 Adds the hability for proposals and budgets components to allow users to give support without being registered. Enabling this feature the user is requested for verification and then, on success, logged in into a 30min session.
 
+The current behavior is as follows. When the logged out user arrives to an action that requires verifiaction the popup offers a new option to allow the user to open a temporal session without the need to signup to the platform. Once selected the form for the first direct verifier found is rendered to the user to fill it.
+On submit, first checks if there's already an authorization for the first direct verifier. If an authorization exists, redirects back and tells the user to use the already verified account, if not, then tries to verify the user with the current data in the form.
+A special case are impersonated (managed) users that are re-authenticated every time.
+
 ## Installation
 
 Add this line to your application's Gemfile:

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Decidim::VerifyWoRegistration
 
-Adds the hability for proposals and budgets components to allow users to give support without being registered. Enabling this feature the user is requested for verification and then, on success, logged in in a 30min session..
+Adds the hability for proposals and budgets components to allow users to give support without being registered. Enabling this feature the user is requested for verification and then, on success, logged in into a 30min session.
 
 ## Installation
 
@@ -13,7 +13,7 @@ gem 'decidim-verify_wo_registration'
 And then execute:
 
 ```bash
-bundle
+bundle install
 ```
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -2,11 +2,6 @@
 
 Adds the hability for proposals and budgets components to allow users to give support without being registered. Enabling this feature the user is requested for verification and then, on success, logged in in a 30min session..
 
-## Usage
-
-VerifyWoRegistration will be available as a Component for a Participatory
-Space.
-
 ## Installation
 
 Add this line to your application's Gemfile:

--- a/app/commands/decidim/verify_wo_registration/do_verify_wo_registration.rb
+++ b/app/commands/decidim/verify_wo_registration/do_verify_wo_registration.rb
@@ -86,7 +86,7 @@ module Decidim
 
       def authorize_user
         transaction do
-          create_or_update_authorizations
+          create_or_update_authorization
           update_user_extended_data
         end
       end
@@ -96,11 +96,10 @@ module Decidim
         user.save!
       end
 
-      def create_or_update_authorizations
-        @form.authorization_handlers.each do |handler|
-          handler.user = user
-          Authorization.create_or_update_from(handler)
-        end
+      def create_or_update_authorization
+        handler= @form.verified_handler
+        handler.user = user
+        Authorization.create_or_update_from(handler)
       end
 
       def user_authorizations

--- a/app/controllers/decidim/verify_wo_registration/verifications_controller.rb
+++ b/app/controllers/decidim/verify_wo_registration/verifications_controller.rb
@@ -38,7 +38,9 @@ module Decidim
         end
       end
 
+      # -------------------------------------------------------------
       private
+      # -------------------------------------------------------------
 
       def form_params
         {
@@ -58,7 +60,7 @@ module Decidim
 
       # Should we validate that only 'direct' verification handlers are enabled?
       def validate_verification_workflow_manifests!
-        return if all_verifications_of_type_direct?(component)
+        return if Decidim::VerifyWoRegistration::ApplicationHelper.verify_wo_registration_custom_modal?(component)
 
         raise 'Invalid verifications, all verifications should be of type direct'
       end

--- a/app/forms/decidim/verify_wo_registration/verify_wo_registration_form.rb
+++ b/app/forms/decidim/verify_wo_registration/verify_wo_registration_form.rb
@@ -63,15 +63,20 @@ module Decidim
         end
       end
 
+      # Provides the handler that verified the user data to the command
+      def verified_handler
+        @verified_handler
+      end
+
       # ----------------------------------------------------------------------
       private
       # ----------------------------------------------------------------------
 
       # Check if the data introduced by the user verifies against any handler enabled for the current component.
       def verify_against_enabled_authorization_handlers
-        verifies_w_some_handler= authorization_handlers.any? {|handler| handler.valid? }
+        @verified_handler= authorization_handlers.find {|handler| handler.valid? }
 
-        errors.add(:authorizations, :invalid) unless verifies_w_some_handler
+        errors.add(:authorizations, :invalid) unless @verified_handler
       end
     end
   end

--- a/app/forms/decidim/verify_wo_registration/verify_wo_registration_form.rb
+++ b/app/forms/decidim/verify_wo_registration/verify_wo_registration_form.rb
@@ -10,7 +10,9 @@ module Decidim
       attribute :redirect_url, String
 
       validates_presence_of :component_id, :redirect_url
+      validate :verify_against_enabled_authorization_handlers
 
+      # Returns authorization_handlers that were configured for the current component
       def authorization_handlers
         @authorization_handlers ||= begin
           ::Decidim::VerifyWoRegistration::ApplicationHelper.workflow_manifests(component).map do |workflow_manifest|
@@ -59,6 +61,17 @@ module Decidim
 
           c
         end
+      end
+
+      # ----------------------------------------------------------------------
+      private
+      # ----------------------------------------------------------------------
+
+      # Check if the data introduced by the user verifies against any handler enabled for the current component.
+      def verify_against_enabled_authorization_handlers
+        verifies_w_some_handler= authorization_handlers.any? {|handler| handler.valid? }
+
+        errors.add(:authorizations, :invalid) unless verifies_w_some_handler
       end
     end
   end

--- a/spec/commands/decidim/verify_wo_registration/do_verify_wo_registration_spec.rb
+++ b/spec/commands/decidim/verify_wo_registration/do_verify_wo_registration_spec.rb
@@ -99,7 +99,7 @@ module Decidim
       context 'when an impersonated user with the same verification already exists' do
         let(:user) { create(:user, :managed, organization: organization) }
 
-        it 'update the existing authorization and login with the same user' do
+        it 'destroy the existing authorization and login with the same user' do
           previously_granted_at = authorization.granted_at
           user.update(extended_data: {
                         component_id: proposals_component.id,
@@ -108,7 +108,8 @@ module Decidim
                         session_expired_at: 30.minutes.ago
                       })
           expect(subject.call).to broadcast(:ok)
-          expect(authorization.reload.granted_at).to be > previously_granted_at
+          expect(Decidim::Authorization.exists?(authorization.id)).to be_falsey
+          expect(Decidim::Authorization.find_by(decidim_user_id: user.id).granted_at).to be > previously_granted_at
           it_sets_users_extended_data(user, previously_granted_at)
         end
 

--- a/spec/controllers/verifications_controller_spec.rb
+++ b/spec/controllers/verifications_controller_spec.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe Decidim::VerifyWoRegistration::VerificationsController, type: :controller do
+  routes { Decidim::VerifyWoRegistration::Engine.routes }
+
+  let(:organization) { component.organization }
+
+  before do
+    request.env["decidim.current_organization"] = organization
+    request.env["decidim.current_participatory_space"] = component.participatory_space
+    request.env["decidim.current_component"] = component
+  end
+
+  describe 'Proposals component with supports_without_registration DISabled' do
+    include_examples 'has a proposal ready to vote'
+    include_examples 'the component has supports_without_registration enabled'
+
+    before do
+      component.attributes['settings']['global']['supports_without_registration'] = false
+      component.save!
+    end
+
+    it "does not render the form" do
+      expect {
+        get(:new, params: {verify_wo_registration: {component_id: component.id}})
+      }.to raise_exception('Invalid verifications, all verifications should be of type direct')
+    end
+
+    it "does not accept POST requests" do
+      expect {
+        post :create, params: {verify_wo_registration: {component_id: component.id}}
+      }.to raise_exception('Invalid verifications, all verifications should be of type direct')
+    end
+  end
+end

--- a/spec/system/verification_spec.rb
+++ b/spec/system/verification_spec.rb
@@ -4,11 +4,11 @@ require 'spec_helper'
 
 describe 'Verification process', type: :system do
   shared_examples 'verifies without being registered' do
-    def fill_the_verification_form_for_dummy_authorization_handler
+    def fill_the_verification_form_for_dummy_authorization_handler(data)
       within('#new_verify_wo_registration_') do
-        fill_in 'verify_wo_registration[authorizations[0]][document_number]', with: '00000000X'
-        fill_in 'verify_wo_registration[authorizations[0]][postal_code]', with: '00000'
-        fill_in 'verify_wo_registration[authorizations[0]][birthday]', with: '2000/01/01'
+        fill_in 'verify_wo_registration[authorizations[0]][document_number]', with: data[:document_number]
+        fill_in 'verify_wo_registration[authorizations[0]][postal_code]', with: data[:postal_code]
+        fill_in 'verify_wo_registration[authorizations[0]][birthday]', with: data[:birthday]
         click_button 'Verify'
       end
     end
@@ -16,13 +16,25 @@ describe 'Verification process', type: :system do
     context 'when correctly filling the form' do
       before do
         click_verify_only
-        fill_the_verification_form_for_dummy_authorization_handler
+        fill_the_verification_form_for_dummy_authorization_handler(document_number: '00000000X', postal_code: '00000', birthday: '2000/01/01')
       end
 
       it 'redirects to the previous page and renders a notice' do
         resource_title= resource.title.kind_of?(Hash) ? translated(resource.title) : resource.title
         expect(page).to have_content(resource_title)
         expect(page).to have_content('You have been successfully verified. You have 30min to participate.')
+      end
+    end
+
+    context 'when filling the form with incorrect data' do
+      before do
+        click_verify_only
+        fill_the_verification_form_for_dummy_authorization_handler(document_number: '12345678A', postal_code: '12345', birthday: '2021/01/27')
+      end
+
+      it 'redirects back to the form and renders the error' do
+        expect(page).to have_selector('#new_verify_wo_registration_')
+        expect(page).to have_content('There was a problem managing the participant.')
       end
     end
   end


### PR DESCRIPTION
This PR fixes the verification process where neither the `VerifyWoRegistrationForm` nor the `DoVerifyWoRegistration` command were actually telling `authorization_handlers` to verify authorization data.

With this fix, the command keeps the previous behavior where first checks if there's already an authorization. If an authorization exists, redirects back and tells the user to use the already verified account, if not, then tries to verify the user with the current data in the form.
A special case are impersonated (managed) users that are re-authenticated every time.

Note that the verification process is implemented in the `VerifyWoRegistrationForm#verify_against_enabled_authorization_handlers`, which delegates the task to the first existing handler of type direct.

Related to #2