### PR TITLE
Refactor and add Warning section

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,8 +38,7 @@ Note that although the only way for participants to open a session is by clickin
 ### Warning
 
 Platform administrators should take care not to reset authorizations while in the middle of a process.
-Reseting authorizations will remove `Authentication`s from existing impersonated users. This will allow participants to vote again in the same process via this module or
-being "manually" impersonated.
+Reseting verifications will remove `Authorization`s from existing impersonated users. This will allow participants to vote again in the same process with the same credentials via this module or being "manually" impersonated.
 
 ## Run tests
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,13 @@ Once enabled, non registered (thus not logged in) participants will have to navi
 
 Note that although the only way for participants to open a session is by clicking the "Support" button, once verified, she will be able to perform all the actions that require the authentications she has verified for.
 
-### Run tests
+### Warning
+
+Platform administrators should take care not to reset authorizations while in the middle of a process.
+Reseting authorizations will remove `Authentication`s from existing impersonated users. This will allow participants to vote again in the same process via this module or
+being "manually" impersonated.
+
+## Run tests
 
 Create a dummy app in your application (if not present):
 

--- a/app/commands/decidim/verify_wo_registration/do_verify_wo_registration.rb
+++ b/app/commands/decidim/verify_wo_registration/do_verify_wo_registration.rb
@@ -26,6 +26,8 @@ module Decidim
             # we can not reuse existing authorization because it will raise "A participant is already authorized with the same data." on @form.valid?
             # as it is an impersonated user, we can safely destroy it and perform the verification process again
             transaction do
+              @user = @authorization.user
+              user.skip_confirmation!
               destroy_authorization
               if @form.valid?
                 authorize_user
@@ -60,13 +62,8 @@ module Decidim
         @user = @authorization.user unless @authorization.user.managed?
       end
 
-      # Searches for an authentication user associated to the given form authorizations
-      # The user should BE managed.
       def existing_impersonated_user?
-        if @authorization.user.managed?
-          @user = @authorization.user
-          user.skip_confirmation!
-        end
+        @authorization.user.managed?
       end
 
       # Some authentication already exists?


### PR DESCRIPTION
Refactors `app/commands/decidim/verify_wo_registration/do_verify_wo_registration.rb` Command for better readability.
This PR also adds a Warning section advising platform administrators to not reset verifications while in the middle of a process.