### PR TITLE
Refactor `lib/decidim/verify_wo_registration/version.rb`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 Current version is defined at `lib/decidim/verify_wo_registration/version.rb`
 
+## Version 0.0.4
+
+- Refactor lib/decidim/verify_wo_registration/version.rb
+
 ## Version 0.0.3
 
 - Make module compatible with Decidim 0.26

--- a/decidim-verify_wo_registration.gemspec
+++ b/decidim-verify_wo_registration.gemspec
@@ -18,11 +18,11 @@ Gem::Specification.new do |s|
 
   s.files = Dir['{app,config,lib}/**/*', 'LICENSE-MIT.txt', 'Rakefile', 'README.md']
 
-  DECIDIM_VER = '>= 0.26'
-  s.add_dependency 'decidim-budgets', DECIDIM_VER
-  s.add_dependency 'decidim-core', DECIDIM_VER
-  s.add_dependency 'decidim-proposals', DECIDIM_VER
-  s.add_development_dependency 'decidim', DECIDIM_VER
-  s.add_development_dependency 'decidim-dev', DECIDIM_VER
-  s.add_development_dependency 'decidim-participatory_processes', DECIDIM_VER
+  
+  s.add_dependency 'decidim-budgets', Decidim::VerifyWoRegistration.decidim_version
+  s.add_dependency 'decidim-core', Decidim::VerifyWoRegistration.decidim_version
+  s.add_dependency 'decidim-proposals', Decidim::VerifyWoRegistration.decidim_version
+  s.add_development_dependency 'decidim', Decidim::VerifyWoRegistration.decidim_version
+  s.add_development_dependency 'decidim-dev', Decidim::VerifyWoRegistration.decidim_version
+  s.add_development_dependency 'decidim-participatory_processes', Decidim::VerifyWoRegistration.decidim_version
 end

--- a/lib/decidim/verify_wo_registration/version.rb
+++ b/lib/decidim/verify_wo_registration/version.rb
@@ -3,8 +3,15 @@
 module Decidim
   # This holds the decidim-meetings version.
   module VerifyWoRegistration
+    VERSION = '0.0.4'
+    DECIDIM_VER = '>= 0.26'
+
     def self.version
-      '0.0.3'
+      VERSION
+    end
+
+    def self.decidim_version
+      DECIDIM_VER
     end
   end
 end


### PR DESCRIPTION
Encapsulate module and Decidim versions into the typical `version.rb` file.