### PR TITLE
Support multiple verifiers at once

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Version 0.2.0
+
+- Support multiple verifiers (handlers) at once.
+
 ## Version 0.1.0
 
 - Upgrade min Decidim version to v0.27.

--- a/app/commands/decidim/verify_wo_registration/do_verify_wo_registration.rb
+++ b/app/commands/decidim/verify_wo_registration/do_verify_wo_registration.rb
@@ -94,9 +94,10 @@ module Decidim
       end
 
       def create_or_update_authorization
-        handler= @form.verified_handler
-        handler.user = user
-        Authorization.create_or_update_from(handler)
+        @form.authorization_handlers.each do |handler|
+          handler.user = user
+          Authorization.create_or_update_from(handler)
+        end
       end
 
       def user_authorizations

--- a/app/forms/decidim/verify_wo_registration/verify_wo_registration_form.rb
+++ b/app/forms/decidim/verify_wo_registration/verify_wo_registration_form.rb
@@ -63,20 +63,15 @@ module Decidim
         end
       end
 
-      # Provides the handler that verified the user data to the command
-      def verified_handler
-        @verified_handler
-      end
-
       # ----------------------------------------------------------------------
       private
       # ----------------------------------------------------------------------
 
-      # Check if the data introduced by the user verifies against any handler enabled for the current component.
+      # Check if the data introduced by the user verifies against all handlers enabled for the current component.
       def verify_against_enabled_authorization_handlers
-        @verified_handler= authorization_handlers.find {|handler| handler.valid? }
+        invalid_handler= authorization_handlers.find {|handler| handler.invalid? }
 
-        errors.add(:authorizations, :invalid) unless @verified_handler
+        errors.add(:authorizations, :invalid) if invalid_handler
       end
     end
   end

--- a/lib/decidim/verify_wo_registration/version.rb
+++ b/lib/decidim/verify_wo_registration/version.rb
@@ -3,7 +3,7 @@
 module Decidim
   # This holds the decidim-meetings version.
   module VerifyWoRegistration
-    VERSION = '0.1.0'
+    VERSION = '0.2.0'
     DECIDIM_VER = '>= 0.27'
 
     def self.version


### PR DESCRIPTION
This PR adds the capability to this module to be used in components configured with more than one verifier (or verification handler).

Before this PR the module was accepting the user as verified with only one of the handlers being valid.